### PR TITLE
Callback migration to core new hook callback

### DIFF
--- a/classes/hook_callbacks.php
+++ b/classes/hook_callbacks.php
@@ -1,0 +1,66 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace assignsubmission_xagree;
+
+use core\hook\output\before_standard_top_of_body_html_generation;
+use html_writer;
+use moodle_url;
+
+/**
+ * Allows the plugin to add any elements to the top of the body.
+ *
+ * @package    assignsubmission_xagree
+ * @copyright  2025 Sumaiya Javed <sumaiya.javed@catalyst.net.nz>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class hook_callbacks {
+    /**
+     * Add the link to download checked submissions to the top of the body.
+     *
+     * @param before_standard_top_of_body_html_generation $hook
+     */
+    public static function before_standard_top_of_body_html_generation(before_standard_top_of_body_html_generation $hook): void {
+        global $PAGE, $OUTPUT, $DB;
+
+
+        if (during_initial_install() || isset($CFG->upgraderunning) || PHPUNIT_TEST) {
+            // Do nothing during installation or upgrade.
+            return;
+        }
+
+        if (!isloggedin()) {
+            return;
+        }
+
+        try {
+
+            if ($PAGE->url->compare(new moodle_url('/mod/assign/view.php'), URL_MATCH_BASE)) {
+                $action = optional_param('action', '', PARAM_TEXT);
+                if ($action == 'grading' && has_capability('mod/assign:grade', $PAGE->context)) {
+                    if ($DB->record_exists('assignsubmission_xagree', ['cmid' => $PAGE->context->instanceid, 'agree' => 1])) {
+                        $url = new moodle_url('/mod/assign/submission/xagree/downloadall.php', array('id' => $PAGE->context->instanceid));
+                        $button = $OUTPUT->single_button($url, get_string('downloadallchecked', 'assignsubmission_xagree'));
+                        $PAGE->set_button($PAGE->button . html_writer::div($button), 'xagree-downloadall');
+                    }
+                }
+            }
+        } catch (\dml_read_exception $e) {
+            // During upgrades, no change.
+            return;
+        }
+    }
+}

--- a/db/hooks.php
+++ b/db/hooks.php
@@ -1,5 +1,5 @@
 <?php
-// This file is part of Moodle - https://moodle.org/
+// This file is part of Moodle - http://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -12,20 +12,22 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Plugin version and other meta-data are defined here.
+ * Hook callbacks for Submission agreement
  *
- * @package     assignsubmission_xagree
- * @copyright   2022 Catalyst IT
- * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @package    assignsubmission_xagree
+ * @copyright  2025 Sumaiya Javed <sumaiya.javed@catalyst.net.nz>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->component = 'assignsubmission_xagree';
-$plugin->release = '2025042300';
-$plugin->version = 2025042300;
-$plugin->requires = 2020110900; // Requires 3.11
-$plugin->maturity = MATURITY_STABLE;
+$callbacks = [
+    [
+        'hook' => \core\hook\output\before_standard_top_of_body_html_generation::class,
+        'callback' => [\assignsubmission_xagree\hook_callbacks::class, 'before_standard_top_of_body_html_generation'],
+        'priority' => 0,
+    ],
+];

--- a/lib.php
+++ b/lib.php
@@ -22,21 +22,4 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
- /**
-  * Add in button to download all checked assignment submissions to assignment grading page.
-  *
-  * @return void
-  */
-function assignsubmission_xagree_before_standard_top_of_body_html() {
-    global $PAGE, $OUTPUT, $DB;
-    if ($PAGE->url->compare(new moodle_url('/mod/assign/view.php'), URL_MATCH_BASE)) {
-        $action = optional_param('action', '', PARAM_TEXT);
-        if ($action == 'grading' && has_capability('mod/assign:grade', $PAGE->context)) {
-            if ($DB->record_exists('assignsubmission_xagree', ['cmid' => $PAGE->context->instanceid, 'agree' => 1])) {
-                $url = new moodle_url('/mod/assign/submission/xagree/downloadall.php', array('id' => $PAGE->context->instanceid));
-                $button = $OUTPUT->single_button($url, get_string('downloadallchecked', 'assignsubmission_xagree'));
-                $PAGE->set_button($PAGE->button . html_writer::div($button), 'xagree-downloadall');
-            }
-        }
-    }
-}
+

--- a/locallib.php
+++ b/locallib.php
@@ -184,7 +184,7 @@ class assign_submission_xagree extends assign_submission_plugin {
      * @return array An array of field names and descriptions. (name=>description, ...)
      */
     public function get_editor_fields() {
-        return array('agreement' => get_string('pluginname', 'assignsubmission_agree'));
+        return array('agreement' => get_string('pluginname', 'assignsubmission_xagree'));
     }
 
     /**


### PR DESCRIPTION
The plugin gives deprecation message on a Moodle 4.5 site. This is fixed with this change

The below is message is displayed
```
Callback before_standard_top_of_body_html in assignsubmission_xagree component should be migrated to new hook callback for core\hook\output\before_standard_top_of_body_html_generation
line 7231 of /lib/moodlelib.php: call to debugging()
line 93 of /lib/classes/hook/output/before_standard_top_of_body_html_generation.php: call to get_plugins_with_function()
line 309 of /lib/classes/output/core_renderer.php: call to core\hook\output\before_standard_top_of_body_html_generation->process_legacy_callbacks()
line 219 of /lib/mustache/src/Mustache/Context.php: call to core\output\core_renderer->standard_top_of_body_html()
line 138 of /lib/mustache/src/Mustache/Context.php: call to Mustache_Context->findVariableInStack()
line 24 of /var/www/moodledata/localcache/mustache/1745382351/catawesome/__Mustache_fa9f95d22704cfcf266278508b6df97d.php: call to Mustache_Context->findDot()
line 67 of /lib/mustache/src/Mustache/Template.php: call to __Mustache_fa9f95d22704cfcf266278508b6df97d->renderInternal()
line 192 of /lib/classes/output/renderer_base.php: call to Mustache_Template->render()
line 207 of /theme/catawesome/layout/columns2.php: call to core\output\renderer_base->render_from_template()
line 972 of /lib/classes/output/core_renderer.php: call to include()
line 888 of /lib/classes/output/core_renderer.php: call to core\output\core_renderer->render_page_layout()
line 179 of /my/index.php: call to core\output\core_renderer->header()
```

Regards,
Sumaiya